### PR TITLE
Add `headertitle` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # A LaTeX template for BA Dresden
-This repository contains a LaTeX template, which tries to follow the [BA Dresden Styleguide](https://www.ba-dresden.de/fileadmin/dresden/downloads/zentrale-dokumente/LEITFADEN_webv2.pdf) as close as possible.
+This repository contains a LaTeX template, which tries to follow the [BA Dresden Styleguide](https://www.ba-dresden.de/fileadmin/M3__BA_Dresden/downloads/zentrale-dokumente/Leitfaden_wissentschaftliche_Arbeiten.pdf) as close as possible.
 __The template might do things wrong and there is no warranty. It is your own responsibility to check for correctness.__
 
 ## Enduser Documentation

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -7,6 +7,7 @@
 \RequirePackage{etoolbox} % for csdef, csundef, ifdefempty, toggles, etc ...
 \newtoggle{baclssimple} % toggles are false per default
 \newtoggle{baclslinkcoloring} % toggles are false per default
+\newtoggle{baclsheader} % toggles are false per default
 
 % first name of the author
 \DeclareOptionX[BA]{first}{\def\@baclsfirst{#1}}
@@ -20,6 +21,10 @@
 \DeclareOptionX[BA]{simple}[usesimple]{\toggletrue{baclssimple}}
 % if specified links will be colored
 \DeclareOptionX[BA]{linkcoloring}[uselinkcoloring]{\toggletrue{baclslinkcoloring}}
+% if specified title will be shown in the header
+\DeclareOptionX[BA]{header}[useheader]{\toggletrue{baclsheader}}
+% if specified header title is changed to tis provided title
+\DeclareOptionX[BA]{headertitle}[no header title provided for headertitle option | it's recommended to use a maximum lentgth of 80 characters to prevent this overflow]{\def\@baclsheadertitle{#1}}
 
 \DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{article}}
 \ProcessOptionsX[BA]\relax
@@ -33,7 +38,11 @@
 \RequirePackage[T1]{fontenc} % change the fontencoding so people can copy accented characters properly from the compiled document
 \RequirePackage{lmodern} % swap the font so that the fontencoding change does not screw up letter kerning
 \fi
-\RequirePackage[a4paper,left=3cm,right=2cm,top=3cm,bottom=2cm]{geometry} % for paper size and page spacing
+\iftoggle{baclsheader}{ % adjust the page top spacing depending on whether header is shown or not
+    \RequirePackage[a4paper,left=3cm,right=2cm,top=3cm,bottom=2cm]{geometry} % for paper size and page spacing
+}{
+    \RequirePackage[a4paper,left=3cm,right=2cm,top=2cm,bottom=2cm]{geometry} % for paper size and page spacing
+}
 \RequirePackage{setspace} % for line spacing
 \RequirePackage{float} % for H placement directive in \begin{figure}
 \RequirePackage{tocloft} % to adjust the ToC, LoF and LoT
@@ -151,12 +160,19 @@
 % Clear the header and footer
 \fancyhead{}
 \fancyfoot{}
-% Add title to the header
-\fancyhead[L]{\@batitletitle}
-% Show the page number on the right side
+
+\iftoggle{baclsheader}{
+    \begingroup\expandafter\expandafter\expandafter\endgroup
+    \expandafter\ifx\csname @baclsheadertitle\endcsname\relax
+        \fancyhead[L]{\@batitletitle} % \@baclsheadertitle is undefined or \relax
+    \else
+        \fancyhead[L]{\@baclsheadertitle} % \@baclsheadertitle is set
+    \fi
+    % Default \headrulewidth is 0.4pt
+    \renewcommand{\headrulewidth}{0.4pt}
+}
+
 \fancyfoot[R]{\thepage}
-% Default \headrulewidth is 0.4pt
-\renewcommand{\headrulewidth}{0.4pt}
 % Default \footrulewidth is 0pt
 % \renewcommand{\footrulewidth}{0.4pt}
 

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -133,7 +133,7 @@
 \pagestyle{fancy}
 % Change pagestyle of ToC pages to fancy
 \tocloftpagestyle{fancy}
-% \renewcommand{\headrulewidth}{0pt}
+\renewcommand{\headrulewidth}{0pt}
 
 % Start with roman page numbering
 \pagenumbering{Roman}

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -30,7 +30,7 @@
 % Load required packages
 \RequirePackage{iftex} % to check the TeX engine in use
 \ifpdftex
-\RequirePackage[T1]{fontenc} % change the fontencoding so people can copy accented chararcters properly from the compiled document
+\RequirePackage[T1]{fontenc} % change the fontencoding so people can copy accented characters properly from the compiled document
 \RequirePackage{lmodern} % swap the font so that the fontencoding change does not screw up letter kerning
 \fi
 \RequirePackage[a4paper,left=3cm,right=2cm,top=3cm,bottom=2cm]{geometry} % for paper size and page spacing

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -164,14 +164,17 @@
 \iftoggle{baclsheader}{
     \begingroup\expandafter\expandafter\expandafter\endgroup
     \expandafter\ifx\csname @baclsheadertitle\endcsname\relax
+        % Add title to the header
         \fancyhead[L]{\@batitletitle} % \@baclsheadertitle is undefined or \relax
     \else
+        % Add title to the header
         \fancyhead[L]{\@baclsheadertitle} % \@baclsheadertitle is set
     \fi
     % Default \headrulewidth is 0.4pt
     \renewcommand{\headrulewidth}{0.4pt}
 }
 
+% Show the page number on the right side
 \fancyfoot[R]{\thepage}
 % Default \footrulewidth is 0pt
 % \renewcommand{\footrulewidth}{0.4pt}

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -8,6 +8,7 @@
 \newtoggle{baclssimple} % toggles are false per default
 \newtoggle{baclslinkcoloring} % toggles are false per default
 \newtoggle{baclsheader} % toggles are false per default
+\toggletrue{baclsheader} % default setting should show the header
 
 % first name of the author
 \DeclareOptionX[BA]{first}{\def\@baclsfirst{#1}}
@@ -21,10 +22,11 @@
 \DeclareOptionX[BA]{simple}[usesimple]{\toggletrue{baclssimple}}
 % if specified links will be colored
 \DeclareOptionX[BA]{linkcoloring}[uselinkcoloring]{\toggletrue{baclslinkcoloring}}
-% if specified title will be shown in the header
-\DeclareOptionX[BA]{header}[useheader]{\toggletrue{baclsheader}}
+% if specified title will not be shown in the header
+\DeclareOptionX[BA]{noheader}[usenoheader]{\togglefalse{baclsheader}}
 % if specified header title is changed to tis provided title
-\DeclareOptionX[BA]{headertitle}[no header title provided for headertitle option | it's recommended to use a maximum lentgth of 80 characters to prevent this overflow]{\def\@baclsheadertitle{#1}}
+% it's recommended to use a maximum lentgth of 80 characters to prevent an overflow
+\DeclareOptionX[BA]{headertitle}[]{\def\@baclsheadertitle{#1}}
 
 \DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{article}}
 \ProcessOptionsX[BA]\relax
@@ -39,9 +41,9 @@
 \RequirePackage{lmodern} % swap the font so that the fontencoding change does not screw up letter kerning
 \fi
 \iftoggle{baclsheader}{ % adjust the page top spacing depending on whether header is shown or not
-    \RequirePackage[a4paper,left=3cm,right=2cm,top=3cm,bottom=2cm]{geometry} % for paper size and page spacing
-}{
     \RequirePackage[a4paper,left=3cm,right=2cm,top=2cm,bottom=2cm]{geometry} % for paper size and page spacing
+}{
+    \RequirePackage[a4paper,left=3cm,right=2cm,top=3cm,bottom=2cm]{geometry} % for paper size and page spacing
 }
 \RequirePackage{setspace} % for line spacing
 \RequirePackage{float} % for H placement directive in \begin{figure}
@@ -162,14 +164,11 @@
 \fancyfoot{}
 
 \iftoggle{baclsheader}{
-    \begingroup\expandafter\expandafter\expandafter\endgroup
-    \expandafter\ifx\csname @baclsheadertitle\endcsname\relax
-        % Add title to the header
-        \fancyhead[L]{\@batitletitle} % \@baclsheadertitle is undefined or \relax
-    \else
-        % Add title to the header
-        \fancyhead[L]{\@baclsheadertitle} % \@baclsheadertitle is set
-    \fi
+    \ifdefvoid{\@baclsheadertitle}{
+        \fancyhead[L]{\@batitletitle}
+    }{
+        \fancyhead[L]{\@baclsheadertitle}
+    }
     % Default \headrulewidth is 0.4pt
     \renewcommand{\headrulewidth}{0.4pt}
 }

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -41,9 +41,9 @@
 \RequirePackage{lmodern} % swap the font so that the fontencoding change does not screw up letter kerning
 \fi
 \iftoggle{baclsheader}{ % adjust the page top spacing depending on whether header is shown or not
-    \RequirePackage[a4paper,left=3cm,right=2cm,top=2cm,bottom=2cm]{geometry} % for paper size and page spacing
-}{
     \RequirePackage[a4paper,left=3cm,right=2cm,top=3cm,bottom=2cm]{geometry} % for paper size and page spacing
+}{
+    \RequirePackage[a4paper,left=3cm,right=2cm,top=2cm,bottom=2cm]{geometry} % for paper size and page spacing
 }
 \RequirePackage{setspace} % for line spacing
 \RequirePackage{float} % for H placement directive in \begin{figure}

--- a/docs/usage/simple.md
+++ b/docs/usage/simple.md
@@ -38,6 +38,8 @@ Let's go through the other package options quickly:
 - `company` should be the company you work for, in case the name contains spaces use `\space` to split the parts, e.g. `part1\space part2`
 - `location` should be the location of university
 - `linkcoloring` changes the text color of links, if `simple` is specified as well
+- `noheader` removes the document title from the header
+- `headertitle` takes an argument to overwrite the header with the new value
 
 Let's also discuss the options of the `basimple` environment:
 - `img` should be a path pointing to the logo of the university


### PR DESCRIPTION
Add 2 options to the `\documentclass` command
+ `header`: controls whether a header line is shown or not
+ `headertitle`: controls the content of the headerline
> If only `header` is provided the title of the document will be used in the header. When `headertitle` is used but not specified a note message will be shown. In case `headertitle` is specified with a value this value will be shown in the header.