### PR TITLE
Update Listof handling

### DIFF
--- a/baarticle.cls
+++ b/baarticle.cls
@@ -14,7 +14,7 @@
 % use package showframe for "debugging"
 % \RequirePackage{showframe}
 
-\usepackage[figure,table]{totalcount}
+\RequirePackage[figure,table]{totalcount}
 
 % first name of the author
 \DeclareOptionX[BA]{first}{\def\@baclsfirst{#1}}

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -9,6 +9,7 @@
 \newtoggle{baclslinkcoloring} % toggles are false per default
 \newtoggle{baclsheader} % toggles are false per default
 \toggletrue{baclsheader} % default setting should show the header
+\newtoggle{dhsnacronyms} % toggles are false per default
 
 % use package showframe for "debugging"
 % \RequirePackage{showframe}
@@ -71,7 +72,7 @@
     \RequirePackage[style=baarticle]{biblatex}
     \RequirePackage{hyperref}
     \RequirePackage[style=alttree,nogroupskip,nonumberlist,nopostdot,nolong,nosuper,nolist]{glossaries}
-    
+
     \iftoggle{baclslinkcoloring}{
         % hyperref config
         \hypersetup{
@@ -120,6 +121,12 @@
 \settowidth{\tabnumspacing}{\bfseries\cfttabpresnum\cfttabaftersnum} % extra space
 \addtolength{\cfttabnumwidth}{\tabnumspacing} % add the extra space
 \setlength{\cfttabindent}{0pt}
+
+% redefine the \newacronym command to set the toggle for the glossary
+\renewcommand{\newacronym}[3]{
+    \newacronym{#1}{#2}{#3}
+    \toggletrue{dhsnacronyms}
+}
 
 % List of Appendix (LoA)
 % The related commands will refer to 'appx' as the appendix command is already defined by LaTeX
@@ -396,12 +403,16 @@
             \clearpage
         }
         \mkfrontmatter{
-            \singlespacing
-            \section*{Abkürzungsverzeichnis}
-            \addcontentsline{toc}{section}{Abkürzungsverzeichnis}
-            \vspace{-1cm}
-            \printnoidxglossaries
-            \onehalfspacing
+            \iftoggle{dhsnacronyms}{
+                \singlespacing
+                \section*{Abkürzungsverzeichnis}
+                \addcontentsline{toc}{section}{Abkürzungsverzeichnis}
+                \vspace{-1cm}
+                \printnoidxglossaries
+                \onehalfspacing
+            }{
+                % do nothing
+            }
         }
     }{
         \printbibliography[heading=bibintoc]

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -13,6 +13,8 @@
 % use package showframe for "debugging"
 % \RequirePackage{showframe}
 
+\usepackage[figure,table]{totalcount}
+
 % first name of the author
 \DeclareOptionX[BA]{first}{\def\@baclsfirst{#1}}
 % last name of the author
@@ -315,11 +317,15 @@
 \newcommand{\mkfrontmatter}[1]{
     \tableofcontents
     \clearpage
-    \listoffigures
+    \iftotalfigures
+        \listoffigures
+    \fi
     \clearpage
     #1
     \clearpage
-    \listoftables
+    \iftotaltables
+        \listoftables
+    \fi
     \clearpage
     \pagenumbering{arabic}
 }

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -400,6 +400,7 @@
         \mkfrontmatter{
             \iftoggle{dhsnacronyms}{
                 \singlespacing
+                \phantomsection
                 \section*{Abkürzungsverzeichnis}
                 \addcontentsline{toc}{section}{Abkürzungsverzeichnis}
                 \vspace{-1cm}

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -122,11 +122,6 @@
 \addtolength{\cfttabnumwidth}{\tabnumspacing} % add the extra space
 \setlength{\cfttabindent}{0pt}
 
-% redefine the \newacronym command to set the toggle for the glossary
-\renewcommand{\newacronym}[3]{
-    \newacronym{#1}{#2}{#3}
-    \toggletrue{dhsnacronyms}
-}
 
 % List of Appendix (LoA)
 % The related commands will refer to 'appx' as the appendix command is already defined by LaTeX
@@ -534,4 +529,15 @@
     \end{table}
     \csundef{@basource}
     \csundef{@baenvtitle}
+}
+
+%updating the \newacronym command to set the toggle for the glossary
+\pretocmd{\newacronym}{
+    \toggletrue{dhsnacronyms}
+}{
+    % patching was successfully
+    \typeout{patched \newacronym command}
+}{
+    % patching failed
+    \typeout{patching of \newacronym command failed}
 }

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -536,8 +536,8 @@
     \toggletrue{dhsnacronyms}
 }{
     % patching was successfully
-    \typeout{patched \newacronym command}
+    \typeout{patched \protect\newacronym command}
 }{
     % patching failed
-    \typeout{patching of \newacronym command failed}
+    \typeout{patching of \protect\newacronym command failed}
 }

--- a/docs/setup/latex.md
+++ b/docs/setup/latex.md
@@ -46,8 +46,8 @@ The templates author uses [VSCode](https://code.visualstudio.com/) with the LaTe
 To get a PDF file from LaTeX code compilation is required.
 Compiling the document requires multiple programs have to be invoked in correct order (`latex` -> `biber` -> `latex` -> `latex`).
 There exist multiple options to automate that process.
-The author strongly recommends to use `latexmk`, as it is easiest to install and use. `latexmk` is already inculded in TeXLive.
-If you use MikTeX, you have to install the `latexmk` package from the MikTex Console. `latexmk` requires Perl, which is not availble per default on Windows.
+The author strongly recommends to use `latexmk`, as it is easiest to install and use. `latexmk` is already included in TeXLive.
+If you use MikTeX, you have to install the `latexmk` package from the MikTex Console. `latexmk` requires Perl, which is not available per default on Windows.
 You might want to install [StrawberryPerl](http://strawberryperl.com/).
 
 ```note

--- a/docs/usage/normal.md
+++ b/docs/usage/normal.md
@@ -64,6 +64,7 @@ It should be obvious that it is possible to move different elements from the beg
     - `date` should be the date when the paper is handed in
     - `location` should be the location of your company
 - `\mkfrontmatter` creates the the table of contents, list of figures, abbreviations and tables
+    - list of figures, abbreviations and tables are only created if they have an entry
     - the first and only argument describes how to create the list of abbreviations. Per default no package is loaded, which can deal with abbreviations. You can choose a package you like.
     - instead of using `\mkfrontmatter` you can build the whole frontmatter yourself using standard LaTeX commands like `\tableofcontents,\listoffigures,\listoftables`
 - `\mkaffirmation` creates the affirmation

--- a/docs/usage/packages.md
+++ b/docs/usage/packages.md
@@ -8,8 +8,8 @@ Below is a list of packages to consider if you need support for a certain task.
 Check out [listings](https://ctan.org/pkg/listings) and [minted](https://ctan.org/pkg/minted).
 The templates author would slightly recommend to use minted, as listings struggles with UTF-8 encoded files and missing highlighting for some common markups such as YAML.
 Minted's highlighting is also more semantic, but minted requires `pygments`, which in turn requires python to be available, and requires passing the `--shell-escape` or `-enable-write18` flag depending on the TeX distribution to the latex compiler.
-## Drawing UML diagramms
+## Drawing UML diagrams
 Check out [pst-uml](https://ctan.org/pkg/pst-uml), [pgf-umlcd](https://ctan.org/pkg/pgf-umlcd) and [pgf-umlsd](https://ctan.org/pkg/pgf-umlsd).
-Alternativly use any tool you like and include an image.
+Alternatively use any tool you like and include an image.
 ## Embedding or attaching files
 Check out [attachfile2](https://ctan.org/pkg/attachfile2), [embedfile](https://ctan.org/pkg/embedfile) and [navigator](https://ctan.org/pkg/navigator).

--- a/docs/usage/simple.md
+++ b/docs/usage/simple.md
@@ -46,16 +46,16 @@ Let's also discuss the options of the `basimple` environment:
 - `course` should be your course of studies
 - `title` should be the title of the paper
 - `number` should be your matriculation number
-- `corrector` should be a comma sperated list of correctors
+- `corrector` should be a comma separated list of correctors
 - `themedate` should be the date when the theme of the paper was announced
 - `returndate` should be the date when the paper is handed in
 - `signature` should be a path to an image of your signature
 - `location` should be the location of your company
 - `type` defines the type of the paper and influences the title page if set to `thesis`, `study` or `report`. Setting the `type` parameter is optional.
-- `assignment` should point to a PDF file containing the assignment to write a thesis. It will include the first page of the given PDF file at the apropiate place. Setting the `assignment` parameter is optional.
+- `assignment` should point to a PDF file containing the assignment to write a thesis. It will include the first page of the given PDF file at the appropriate place. Setting the `assignment` parameter is optional.
 - `blocknotice` defines whether a blocknotice should be included or not if set to `false`. One will be included per default. Setting the `blocknotice` parameter is optional.
 
-To add an abstract to the paper define a macro called `\basimpleabstract` which replacement text is the abtract's content. The following should do it (the `\addcontentsline` is optional):
+To add an abstract to the paper define a macro called `\basimpleabstract` which replacement text is the abstract's content. The following should do it (the `\addcontentsline` is optional):
 ```latex
 \documentclass[...,simple]{baarticle}
 
@@ -109,7 +109,7 @@ By the way these references are also clickable links.
     \end{basimple}
 \end{document}
 ```
-Images can be inculded with `\includegraphics`, which should be wrapped in a `bafigure` environment.
+Images can be included with `\includegraphics`, which should be wrapped in a `bafigure` environment.
 The number of a figure can be retrieved using `\ref{caption}` with the caption provided to the environment.
 `\includegraphics` has a lot of optional arguments, e.g. for rotating and scaling images.
 Take a look [here](https://latexref.xyz/_005cincludegraphics.html).
@@ -135,7 +135,7 @@ Tables should also be wrapped in a `batable` environment.
 \end{document}
 ```
 An appendix can be created using the `baappx` environment, which will also create an overview of all appendix entries.
-Most environments introduced by this template feature some customization options, which are describe in the [environments](./environments) section.
+Most environments introduced by this template feature some customization options, which are described in the [environments](./environments) section.
 ```latex
 \documentclass[...]{baarticle}
 
@@ -150,8 +150,8 @@ Most environments introduced by this template feature some customization options
     \end{basimple}
 \end{document}
 ```
-It is worthwhile to split up larger documents into mulitple files.
-You can put each chapter into a separat `.tex` file and join them in the main file using `\include{path/to/the/file}`.
+It is worthwhile to split up larger documents into multiple files.
+You can put each chapter into a separate `.tex` file and join them in the main file using `\include{path/to/the/file}`.
 Given the following file tree:
 ```text
 somedirectory
@@ -183,7 +183,7 @@ This should work.
 The template uses the biblatex package to deal with the bibliography and citations and provides customized styles for it, which are automatically loaded in simple mode.
 Biblatex own its own has a load functionality, so feel free to consult their [documentation](https://ctan.mc1.root.project-creative.net/macros/latex/contrib/biblatex/doc/biblatex.pdf) and [cheatsheet](http://tug.ctan.org/info/biblatex-cheatsheet/biblatex-cheatsheet.pdf).
 
-At first it is required to setup a bibliography database.
+At first it is required to set up a bibliography database.
 One needs to create a file with the `.bib` extension in the file tree.
 ```text
 somedirectory
@@ -250,7 +250,7 @@ This template covers the `@article`, `@book`, `@online`, `@collection`, `@incoll
  Additional attributes should not be required and may use a wrong formatting. The same holds true for other entry types. Be aware.
 ```
 Now one can create references in the `.tex` file.
-Refering to sources in the text can be achieved with the `\bacite{citekey}` command for direct citations and the the `\vglcite{citekey}` command for indirect citations.
+Referring to sources in the text can be achieved with the `\bacite{citekey}` command for direct citations and the `\vglcite{citekey}` command for indirect citations.
 `\enquote{content}` puts its argument in quotation marks.
 The optional numbers given to the cite commands in the brackets describe the pages, where the information can be found in the sources.
 Footnotes for citations and the final bibliography are generated automatically.

--- a/test.tex
+++ b/test.tex
@@ -57,7 +57,7 @@
     \clearpage
     \subsection*{Lengths}
     \edef\test{\strip@pt\parindent}\assert[parindent is 0]{0}
-    \edef\test{\headrulewidth}\assert[headrulewidth is 0pt]{0pt}
+    \edef\test{\headrulewidth}\assert[headrulewidth is 0.4pt]{0.4pt}
 
     \subsection*{Table of Contents\, List of Figures and Tables}
     \edef\test{\cftsecdotsep}\assert[ToC lines filled with dots]{\cftdot}


### PR DESCRIPTION
Now the template kinda auto decides whether the list of figures, tables and abbreviations is shown or not.

New package: `totalcount`
Redefining `newacronym` (could be a problem)