### PR TITLE
chore: Update TOC entries

### DIFF
--- a/baarticle.cls
+++ b/baarticle.cls
@@ -35,6 +35,8 @@
 \DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{article}}
 \ProcessOptionsX[BA]\relax
 
+\pretocmd{\printbibliography}{\phantomsection}{}{}
+
 % Class is based on the deault article class
 \LoadClass[12pt]{article}
 

--- a/baarticle.cls
+++ b/baarticle.cls
@@ -64,6 +64,7 @@
 \RequirePackage{titlesec} % to reduce section spacing
 \RequirePackage{lipsum} % just to generate text for the example
 \RequirePackage[figure,table,code]{totalcount} % count entries in LoF and LoT, LoC
+\RequirePackage[bookmarksnumbered=true]{hyperref}
 
 % Load additional packages if in simple mode
 \iftoggle{baclssimple}{

--- a/minimal.tex
+++ b/minimal.tex
@@ -44,7 +44,8 @@
     number=1234,
     corrector={corrector 1,corrector 2},
     themedate=\today,
-    returndate=\today
+    returndate=\today,
+    type=thesis
 }
 \mkblocknotice{
     signature=images/signature.png,

--- a/test.tex
+++ b/test.tex
@@ -40,7 +40,8 @@
     number=1234,
     corrector={corrector 1,corrector 2},
     themedate=\today,
-    returndate=\today
+    returndate=\today,
+    type=thesis
 }
 \clearpage
 \edef\test{\thepage}\assert[title page increases page counter]{II}


### PR DESCRIPTION
- Add `\phantomsection` in front of bibliography so the TOC link now redirects to the correct element
- Add `bookmarksnumbered` option from `hyperref` package so the entries of the PDF builtin TOC are now numbered (requirement by Jürgen Sachse)